### PR TITLE
processed mentor's feedback on hero cta button and how-we-do section (mobile)

### DIFF
--- a/src/partials/hero.html
+++ b/src/partials/hero.html
@@ -7,7 +7,7 @@
         <p class="hero__content-item__description">
           But you’re are guaranteed to get <span class="--accent-color">+25 points</span>
         </p>
-        <button type="button" class="hero__button">I want a free lesson</button>
+        <a href="#contacts" class="hero__button">I want a free lesson</a>
       </li>
       <li class="hero__content-item"></li>
     </ul>

--- a/src/sass/_how-we-do.scss
+++ b/src/sass/_how-we-do.scss
@@ -1,5 +1,5 @@
 .how-we-do {
-  padding-top: 50px;
+  padding-top: 0;
   padding-bottom: 50px;
 }
 


### PR DESCRIPTION
Removed top padding from how-we-do section on mobile and tablet, added anchor in the hero cta button